### PR TITLE
Add BSIP 45 - "Introduce 'allow use as bitasset backing collateral' flag/permission to assets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Number             | Title                                                    | 
 [39](bsip-0039.md) | Automatically approve proposals by the proposer                             | Fabian Schuh | Protocol | Draft
 [40](bsip-0040.md) | Custom active permission                             | Stefan Schießl | Protocol | Draft
 [42](bsip-0042.md) | Adjust price feed to influence trading price of SmartCoins                  | Abit More | Protocol | Draft
+[45](bsip-0045.md) | Introduce 'allow use as bitasset backing collateral' flag/permission to assets | Customminer | Protocol | Draft

--- a/bsip-0021.md
+++ b/bsip-0021.md
@@ -107,7 +107,7 @@ for each asset_holder in coin_age_hashmap {
 
 # Copyright
 
-N/A - Consider this BSIP entirely open-source/MIT-licensed, I am not the originator of the concept of 'coin-age' (several proof-of-stake cryptocurrencies make use of coin-age for finding stakable coins).
+This document is placed in the public domain.
 
 # See Also
 * [List account balances - Graphene documentation](http://docs.bitshares.org/api/database.html#id8)

--- a/bsip-0022.md
+++ b/bsip-0022.md
@@ -119,7 +119,7 @@ Please do raise your concerns, propose improvements and engage in the BSIP creat
 
 # Copyright
 
-This document is placed in the public domain, 100% open source & should be considered MIT licensed.
+This document is placed in the public domain.
 
 # See Also
 

--- a/bsip-0023.md
+++ b/bsip-0023.md
@@ -651,7 +651,7 @@ The Bitshares starship drops out of hyperspace in planet Bitcoin's orbit, the cr
 
 # Copyright
 
-This document is placed in the public domain, 100% open source & should be considered MIT licensed.
+This document is placed in the public domain.
 
 # See Also
 

--- a/bsip-0024.md
+++ b/bsip-0024.md
@@ -62,7 +62,7 @@ Would there even be a difference in voting behaviour betwen the two? Perhaps it 
 
 # Copyright
 
-This document is placed in the public domain, 100% open source & should be considered MIT licensed.
+This document is placed in the public domain.
 
 # See Also
 

--- a/bsip-0045.md
+++ b/bsip-0045.md
@@ -1,0 +1,85 @@
+BSIP: 45
+Title: Introduce 'allow use as bitasset backing collateral' flag/permission to assets
+Authors: @grctest
+Status: Draft
+Type: Protocol
+Created: 07/10/2018
+Discussion:  https://github.com/bitshares/bsips/issues/80
+Replaces: N/A
+Superseded-By: N/A
+Worker: N/A
+
+---
+
+# Abstract
+
+It's currently possible to impose new asset settings through MPA encapsulation without the permission of the backing asset's 'asset owner'.
+
+This BSIP proposes to introduce a new asset permission/flag which enables the asset owner to enable|prevent MPA encapsulation.
+
+# Motivation
+
+By encapsulating an asset (UIA/EBA|MPA) within a new MPA, you can impose new asset settings upon the underlying asset, to the possible detriment of the backing asset's 'asset owner'.
+
+# Rational
+
+By providing asset owners this functionality, we can improve asset owner confidence in the finality of their configured asset settings.
+
+# Specifications
+
+## Create new 'allow use as backing collateral' flag/permission
+
+Rather than create a system of inheriting permissions from backing collateral, a new flag/permission for 'allow use as MPA backing collateral' could simply prevent MPA encapsulation entirely at the discretion of the asset owner.
+
+Existing assets which are currently configured as an bitasset's backing collateral would require this flag to be set default enabled (allowed). This couldn't be changed unless the bitasset reconfigured to an alternative backing collateral - impossible if supply is greater than 0.
+
+Non applicable assets (PM & twice nested MPA) would prevent the flag from being enabled.
+
+Existing assets currently not used as backing collateral could be set to disabled by default.
+
+# Discussion
+
+## Consequences of MPA encapsulation
+
+* Removal/Bypassing of market fees (if enabled)
+* Re-implementation of confidential transfers (if disabled)
+* Evasion of whitelist/blacklist (both user & market lists)
+* Preventing the issuer from transfering the asset back to themselves (Can't transfer backing collateral back to yourself)
+* Remove backing asset issuer from transfer approval provess.
+
+## Committee configuration
+
+Should all smartcoins be allowed as bitasset backing collateral? Given that XCD already does this with bitUSD, I think it's appropriate. That said, not all committee owned bitassets are in a stable state (bitGOLD for example is in global settlement state right now).
+
+## Enabling the flag grants permisson for all
+
+Currently you can perform MPA encapsulation without involving the asset owner, this could introduce conflict between the two asset owners.
+
+If the flag is enabled, that's an indication that the asset owner accepts any bitasset use case - you wouldn't need to seek explicit permission prior to creating experimental bitassets on the BTS DEX. 
+
+If it's disabled, that's a clear indication that the asset owner doesn't want it used as backing collateral.
+
+## How to configure assets held by null-account?
+
+It's possible that bitassets may be owned by null-account but remain operational, configuring default disabled would burn the possibility of encapsulation - if these assets exist then if possible should be set to enabled?
+
+## Proposed UI changes
+
+This flag could only work as long as no MPA has already selected the asset as its backing collateral; setting this as default disabled (not allowed) for newly created assets in the asset creation form could help prevent the asset being used as backing collateral without the user's knowledge.
+
+---
+
+# Summary for Shareholders
+
+* Would likely require a hard fork.
+* Introduces new asset owner permissions.
+* Helps mitigate negative MPA encapsulation consequences, improving gateway regulatory compliance capability?
+* Given enabled flags could constitute advanced permission for MPA use case, there may be UIA backed MPA created which would contribute BTS fees to the reserve pool.
+
+# Copyright
+
+This document is placed in the public domain, 100% open source & should be considered MIT licensed.
+
+# See Also
+
+N/A

--- a/bsip-0045.md
+++ b/bsip-0045.md
@@ -72,7 +72,6 @@ This flag could only work as long as no MPA has already selected the asset as it
 
 # Summary for Shareholders
 
-* Would likely require a hard fork.
 * Introduces new asset owner permissions.
 * Helps mitigate negative MPA encapsulation consequences, improving gateway regulatory compliance capability?
 * Given enabled flags could constitute advanced permission for MPA use case, there may be UIA backed MPA created which would contribute BTS fees to the reserve pool.

--- a/bsip-0045.md
+++ b/bsip-0045.md
@@ -1,3 +1,4 @@
+```
 BSIP: 45
 Title: Introduce 'allow use as bitasset backing collateral' flag/permission to assets
 Authors: @grctest
@@ -8,7 +9,7 @@ Discussion:  https://github.com/bitshares/bsips/issues/80
 Replaces: N/A
 Superseded-By: N/A
 Worker: N/A
-
+```
 ---
 
 # Abstract

--- a/bsip-0045.md
+++ b/bsip-0045.md
@@ -78,7 +78,7 @@ This flag could only work as long as no MPA has already selected the asset as it
 
 # Copyright
 
-This document is placed in the public domain, 100% open source & should be considered MIT licensed.
+This document is placed in the public domain.
 
 # See Also
 


### PR DESCRIPTION
```
BSIP: 45
Title: Introduce 'allow use as bitasset backing collateral' flag/permission to assets
Authors: Customminer
Status: Draft
Type: Protocol
Created: N/A
Discussion:  https://github.com/bitshares/bsips/issues/80
Replaces: N/A
Superseded-By: N/A
Worker: N/A
```