### PR TITLE
BSIP40: change operation_id to operation_type

### DIFF
--- a/bsip-0040.md
+++ b/bsip-0040.md
@@ -48,7 +48,7 @@ This BSIP will be split into parts that will be voted on separately (see Milesto
 
 # Rationale
 
-Custom active permission is a list of `custom active authorities`. A `custom active authority` contains an `operation_id`, 
+Custom active permission is a list of `custom active authorities`. A `custom active authority` contains an `operation_type`, 
 an `authority` (just like with active permission) and `restrictions` than can be used to restrict arguments. 
 Furthermore, such a `custom active authority` is only valid in a specified time period (`valid_from` and `valid_to`). 
 When handling incoming signed transactions, the backend checks 
@@ -74,7 +74,7 @@ custom_active_authority = {
     enabled,                // status of this authority, true or false. true when created
     valid_from,             // timestamp when this is active
     valid_to,               // timestamp when this is invalid
-    operation_id,           // operation id of the target operation,
+    operation_type,         // type of the target operation,
     authority,              // same as for the existing authotities (multisig with weighted accounts or keys),
     restrictions            // see below
 }
@@ -82,7 +82,7 @@ custom_active_authority = {
 Note: This assumes `custom_active_permission` is stored in a separate index. Actual implementation details left to the implementer, as long as every `custom_active_permission` can be assigned to exactly one account.
 
 A `custom active authority` is matched against operations of an incoming, signed transaction. The wording *matching* refers to:
-- `operation_id` is equal to the id of the incoming operation
+- `operation_type` is equal to the type of the incoming operation
 - `account_id` is in the required accounts of the operation
 - the `authority` of the `custom_active_authority` is given by the signatures of the transaction
 - timestamp `now` is within `valid_to` and `valid_from` 
@@ -251,7 +251,7 @@ The custom active authority should be put such that a transfer transaction sendi
 custom active authority = {
     valid_from: 7.7.2018 00:00
     valid_to: 8.7.2018 00:00
-    operation_id: transfer,
+    operation_type: transfer,
     authority: {
        threshold: 1
        key_auth: [key K, 1]
@@ -319,7 +319,7 @@ More concrete, the authority would look like
 custom active authority = {
     valid_from: 7.7.2018 00:00
     valid_to: 8.7.2018 00:00
-    operation_id: transfer,
+    operation_type: transfer,
     authority: {
        threshold: 1
        key_auth: []


### PR DESCRIPTION
in order to reduce confusion.