### PR TITLE
Update market URI in BSIP60

### DIFF
--- a/bsip-0060.md
+++ b/bsip-0060.md
@@ -131,11 +131,19 @@ lowalpha             = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" |
 
 Market paths start with the word "market", followed by two `asset_id_or_symbol`s.
 
-Example: `market/BTS_USD`
+Example:
+* `market/BTS/USD`
+* `market/BTS_USD`
 
 ```BNF
-market_path = "market" "/" asset_id_or_symbol "_" asset_id_or_symbol
+market_path = "market" "/" asset_id_or_symbol [ "/" | "_" ] asset_id_or_symbol
 ```
+
+Note:
+the `/` character has been chosen as the most preferable separator between the assets.
+Due to historical reasons, the `_` separator had already been used in some applications
+before the first version of this document was published.
+New applications may consider supporting both for compatibility.
 
 ### Public Keys
 

--- a/bsip-0060.md
+++ b/bsip-0060.md
@@ -131,10 +131,10 @@ lowalpha             = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" |
 
 Market paths start with the word "market", followed by two `asset_id_or_symbol`s.
 
-Example: `market/BTS/USD`
+Example: `market/BTS_USD`
 
 ```BNF
-market_path = "market" "/" asset_id_or_symbol "/" asset_id_or_symbol
+market_path = "market" "/" asset_id_or_symbol "_" asset_id_or_symbol
 ```
 
 ### Public Keys


### PR DESCRIPTION
Due to historical reasons the reference wallet and some blockchain explorers implemented `market/asset_asset` scheme, so I think it's better to stick with it. E.G.
* https://wallet.bitshares.org/#/market/BTS_CNY
* https://bts.ai/market/BTS_CNY
* https://cryptofresh.com/a/BTS_CNY