### PR TITLE
BSIP 64: Optional HTLC Preimage Length and Add Hash160 Algorithm

### DIFF
--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -18,6 +18,8 @@ The original implementation of Hashed Timelock Contracts included a protection t
 
 In addition, BIP199 includes the ability to use HASH160, which is not currently part of the BitShares implementation.
 
+And finally, when participating in atomic cross-chain swaps (a major benefit of HTLCs), some extra information is necessary. An optional `memo` field should be added.
+
 Risks
 ===============
 **Note** below is a discussion of HTLC risks in general, not risks inherent in implementing this BSIP.
@@ -44,6 +46,8 @@ Technically, the implementation of these changes are small.
 
 **HASH160**: Include this additional hashing algorithm to the list of hashes available to be used. Note: A "HASH160" is simply RIPEMD160(SHA256(preimage)).
 
+**Memo**: Include this optional field for users to have an area for free-form data.
+
 Discussion
 ===================
 While it is highly recommended that both halves of an atomic transaction provide explicit preimage lengths, the requirement as currently implemented in BitShares Core makes it incompatible with other "standardized" implementations. With the loosening of the preimage length requirement, atomic swaps that require such "standard" rules can be created on the BitShares blockchain.
@@ -61,4 +65,5 @@ See Also
 [Bitshares BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md)
 [Bitcoin BIP 199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki)
 [Preimage Size Attack](https://gist.github.com/markblundeberg/7a932c98179de2190049f5823907c016)
+[HTLC Operations memo](https://github.com/bitshares/bitshares-core/issues/1967)
 

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -26,6 +26,8 @@ Risks
 
 This can be mitigated by specifying the preimage size as part of the contract. This feature is available on many bitcoin-based chains among others, but is not standard. Should the preimage size be used with an atomic swap, both sides of the transaction should include the preimage size in their contract.
 
+One item to keep in mind is that although a preimage size may not be explicitly specified, implicit limitations may exist. For insance, a blockchain may have limitations that make a transaction valid on one chain, but invalid on another (i.e. maximum transaction size). 
+
 **Timelock Attacks** It is standard practice for HTLCs that the timelock should be long enough so that the block that contains the contract can be considered irreversible. This makes it possible for the redeemer to expose the preimage and still be guaranteed that the contract itself will not be reversed.
 
 This becomes even more important with atomic swaps. The shorter duration (a.k.a “inner”) contract should allow time to achieve its own irreversibility. And the longer duration (a.k.a. “outer”) contract must allow time for irreversibility of both.
@@ -36,15 +38,19 @@ One final consideration of the timelock portion of the contract is the use of ca
 
 Specifications
 =========
-Technically, the impelentation of these changes are small.
+Technically, the implementation of these changes are small.
 
 **Preimage Size**: Permit that an HTLC can have the preimage size set to 0. This removes the size check during validation.
 
-**HASH160**: Include this additional hashing algorithm to the list of hashes available to be used.
+**HASH160**: Include this additional hashing algorithm to the list of hashes available to be used. Note: A "HASH160" is simply RIPEMD160(SHA256(preimage)).
 
 Discussion
 ===================
-https://github.com/bitshares/bsips/issues/163
+While it is highly recommended that both halves of an atomic transaction provide explicit preimage lengths, the requirement as currently implemented in BitShares Core makes it incompatible with other "standardized" implementations. With the loostening of the preimage length requirement, atomic swaps that require such "standard" rules can be created on the BitShares blockchain.
+
+In addition, adding the HASH160 algorithm adds to the compatibility of BitShares Core with other blockchains.
+
+Additional discussion can be found in the issue related to this PR at https://github.com/bitshares/bsips/issues/163
 
 Copyright
 ====================

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -1,0 +1,58 @@
+```
+BSIP: 64
+Title: Optional HTLC preimage length and HASH160 addition
+Authors: John Jones <jmjatlanta@gmail.com>, abitmore
+Status: Draft
+Type: Protocol
+Created: 2019-07-09
+Discussion: https://github.com/bitshares/bsips/issues/163
+```
+
+Abstract
+===================
+This BSIP proposes two changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions.
+
+Motivation
+=================
+The original implementation of Hashed Timelock Contracts included a protection to prevent an attack based on the size of the preimage. While it is still believed this is a valuable feature, this makes the implementation incompatible with a strict implementation of the popular [BIP199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki) implemented by Bitcoin.
+
+In addition, BIP199 includes the ability to use HASH160, which is not currently part of the BitShares implementation.
+
+Risks
+===============
+**Note** below is a discussion of HTLC risks in general, not risks inherent in implementing this BSIP.
+
+**An Oversized Preimage Attack** There are limits to the size of a preimage that can be used. That limit is set by the blockchain itself. But when dealing with atomic swaps across blockchains, an attacker could use a preimage that is too large for one side of the 2 sided transaction. That means that an HTLC can be created on both chains, but only redeemed on one chain, and not the other.
+
+This can be mitigated by specifying the preimage size as part of the contract. This feature is available on many bitcoin-based chains among others, but is not standard. Should the preimage size be used with an atomic swap, both sides of the transaction should include the preimage size in their contract.
+
+**Timelock Attacks** It is standard practice for HTLCs that the timelock should be long enough so that the block that contains the contract can be considered irreversible. This makes it possible for the redeemer to expose the preimage and still be guaranteed that the contract itself will not be reversed.
+
+This becomes even more important with atomic swaps. The shorter duration (a.k.a “inner”) contract should allow time to achieve its own irreversibility. And the longer duration (a.k.a. “outer”) contract must allow time for irreversibility of both.
+
+In addition, with an atomic swap both sides must consider the redemption time necessary. The creator of the inner contract must decide that should the redeemer redeem at the last moment, is there enough time to redeem the outer contract before the timelock expires.
+
+One final consideration of the timelock portion of the contract is the use of capital. Should the other party not accept, the funds in the contract are held until the timelock expires. Long expiration times could result in missed opportunity costs.
+
+Specifications
+=========
+Technically, the impelentation of these changes are small.
+
+**Preimage Size**: Permit that an HTLC can have the preimage size set to 0. This removes the size check during validation.
+
+**HASH160**: Include this additional hashing algorithm to the list of hashes available to be used.
+
+Discussion
+===================
+https://github.com/bitshares/bsips/issues/163
+
+Copyright
+====================
+This document is placed in the public domain.
+
+See Also
+===================
+[Bitshares BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md)
+[Bitcoin BIP 199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki)
+[Preimage Size Attack](https://gist.github.com/markblundeberg/7a932c98179de2190049f5823907c016)
+

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -46,7 +46,7 @@ Technically, the implementation of these changes are small.
 
 **HASH160**: Include this additional hashing algorithm to the list of hashes available to be used. Note: A "HASH160" is simply RIPEMD160(SHA256(preimage)).
 
-**Memo**: Include this optional field for users to have an area for free-form data. It should work as does the memo field in typical BitShares transactions.
+**Memo**: Include this optional field for users to have an area for free-form data. It should work as does the memo field in typical BitShares transactions. This should be implemented as an extension of the `htlc_create_operation`. *Note:* adding to the htlc_object is not necessary, as existing in transaction history is sufficient.
 
 Discussion
 ===================

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -26,7 +26,7 @@ Risks
 
 This can be mitigated by specifying the preimage size as part of the contract. This feature is available on many bitcoin-based chains among others, but is not standard. Should the preimage size be used with an atomic swap, both sides of the transaction should include the preimage size in their contract.
 
-One item to keep in mind is that although a preimage size may not be explicitly specified, implicit limitations may exist. For insance, a blockchain may have limitations that make a transaction valid on one chain, but invalid on another (i.e. maximum transaction size). 
+One item to keep in mind is that although a preimage size may not be explicitly specified, implicit limitations may exist. For instance, a blockchain may have limitations that make a transaction valid on one chain, but invalid on another (i.e. maximum transaction size). 
 
 **Timelock Attacks** It is standard practice for HTLCs that the timelock should be long enough so that the block that contains the contract can be considered irreversible. This makes it possible for the redeemer to expose the preimage and still be guaranteed that the contract itself will not be reversed.
 
@@ -46,7 +46,7 @@ Technically, the implementation of these changes are small.
 
 Discussion
 ===================
-While it is highly recommended that both halves of an atomic transaction provide explicit preimage lengths, the requirement as currently implemented in BitShares Core makes it incompatible with other "standardized" implementations. With the loostening of the preimage length requirement, atomic swaps that require such "standard" rules can be created on the BitShares blockchain.
+While it is highly recommended that both halves of an atomic transaction provide explicit preimage lengths, the requirement as currently implemented in BitShares Core makes it incompatible with other "standardized" implementations. With the loosening of the preimage length requirement, atomic swaps that require such "standard" rules can be created on the BitShares blockchain.
 
 In addition, adding the HASH160 algorithm adds to the compatibility of BitShares Core with other blockchains.
 

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -1,6 +1,6 @@
 ```
 BSIP: 64
-Title: Optional HTLC preimage length and HASH160 addition
+Title: Optional HTLC preimage length, HASH160 addition, and memo field
 Authors: John Jones <jmjatlanta@gmail.com>, abitmore
 Status: Draft
 Type: Protocol
@@ -10,7 +10,7 @@ Discussion: https://github.com/bitshares/bsips/issues/163
 
 Abstract
 ===================
-This BSIP proposes two changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions.
+This BSIP proposes three changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions. And the third creates an optional `memo` field.
 
 Motivation
 =================
@@ -46,7 +46,7 @@ Technically, the implementation of these changes are small.
 
 **HASH160**: Include this additional hashing algorithm to the list of hashes available to be used. Note: A "HASH160" is simply RIPEMD160(SHA256(preimage)).
 
-**Memo**: Include this optional field for users to have an area for free-form data.
+**Memo**: Include this optional field for users to have an area for free-form data. It should work as does the memo field in typical BitShares transactions.
 
 Discussion
 ===================
@@ -62,8 +62,8 @@ This document is placed in the public domain.
 
 See Also
 ===================
-[Bitshares BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md)
-[Bitcoin BIP 199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki)
-[Preimage Size Attack](https://gist.github.com/markblundeberg/7a932c98179de2190049f5823907c016)
-[HTLC Operations memo](https://github.com/bitshares/bitshares-core/issues/1967)
+[Bitshares BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md)  
+[Bitcoin BIP 199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki)  
+[Preimage Size Attack](https://gist.github.com/markblundeberg/7a932c98179de2190049f5823907c016)  
+[HTLC Operations memo](https://github.com/bitshares/bitshares-core/issues/1967)  
 


### PR DESCRIPTION
This BSIP will remove the requirement of a preimage length (making it optional), and adding an additional hash algorithm.

This PR fixes Issue https://github.com/bitshares/bsips/issues/163