### PR TITLE
Remove SHA1

### DIFF
--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -10,13 +10,13 @@ Discussion: https://github.com/bitshares/bsips/issues/163
 
 Abstract
 ===================
-This BSIP proposes three changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions. And the third creates an optional `memo` field.
+This BSIP proposes three changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions. The third removes the SHA1 algorithm. And the fourth creates an optional `memo` field.
 
 Motivation
 =================
 The original implementation of Hashed Timelock Contracts included a protection to prevent an attack based on the size of the preimage. While it is still believed this is a valuable feature, this makes the implementation incompatible with a strict implementation of the popular [BIP199](https://github.com/bitcoin/bips/blob/master/bip-0199.mediawiki) implemented by Bitcoin.
 
-In addition, BIP199 includes the ability to use HASH160, which is not currently part of the BitShares implementation.
+In addition, BIP199 includes the ability to use HASH160, which is not currently part of the BitShares implementation. SHA1 is not part of BIP199, but was implemented although not recommended. It is best to remove SHA1.
 
 And finally, when participating in atomic cross-chain swaps (a major benefit of HTLCs), some extra information is necessary. An optional `memo` field should be added.
 
@@ -46,6 +46,8 @@ Technically, the implementation of these changes are small.
 
 **HASH160**: Include this additional hashing algorithm to the list of hashes available to be used. Note: A "HASH160" is simply RIPEMD160(SHA256(preimage)).
 
+**SHA1**: Remove this hashing algorithm as it is considered unsafe.
+
 **Memo**: Include this optional field for users to have an area for free-form data. It should work as does the memo field in typical BitShares transactions. This should be implemented as an extension of the `htlc_create_operation`. *Note:* adding to the htlc_object is not necessary, as existing in transaction history is sufficient.
 
 Discussion
@@ -53,6 +55,8 @@ Discussion
 While it is highly recommended that both halves of an atomic transaction provide explicit preimage lengths, the requirement as currently implemented in BitShares Core makes it incompatible with other "standardized" implementations. With the loosening of the preimage length requirement, atomic swaps that require such "standard" rules can be created on the BitShares blockchain.
 
 In addition, adding the HASH160 algorithm adds to the compatibility of BitShares Core with other blockchains.
+
+SHA1 is considered an unsafe hashing algorithm, and should not be an available option for HTLCs.
 
 Additional discussion can be found in the issue related to this PR at https://github.com/bitshares/bsips/issues/163
 

--- a/bsip-0064.md
+++ b/bsip-0064.md
@@ -10,7 +10,7 @@ Discussion: https://github.com/bitshares/bsips/issues/163
 
 Abstract
 ===================
-This BSIP proposes three changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions. The third removes the SHA1 algorithm. And the fourth creates an optional `memo` field.
+This BSIP proposes four changes to Hashed Time Lock Contracts (HTLC) defined in [BSIP 44](https://github.com/bitshares/bsips/blob/master/bsip-0044.md). The first makes the preimage `length` parameter optional. The second adds the HASH160 algorithm to the set of allowed hash functions. The third removes the SHA1 algorithm. And the fourth creates an optional `memo` field.
 
 Motivation
 =================


### PR DESCRIPTION
This PR will request removal of the SHA1 algorithm from HTLCs as par of BSIP 64.