### PR TITLE
Re-add BSIP-83: Decouple BitAssets from Platform Governance Process

### DIFF
--- a/bsip-0083.md
+++ b/bsip-0083.md
@@ -1,0 +1,88 @@
+```
+BSIP: 0083
+Title: Decouple BitAssets from Platform Governance Process
+Authors:    
+   Alfredo Garcia
+   Christopher Sanborn
+   John M. Jones
+   Michel Santos
+   Nathan Hourt
+   Peter Conrad
+   Ryan R. Fox
+Status: Draft
+Type: Protocol
+Obsoletes: BSIP-0016, BSIP-0058, BSIP-0059, BSIP-0076
+Created: 2019-10-07
+Discussion: https://github.com/bitshares/bsips/issues/239
+Worker: <TBD>
+```
+
+# Abstract
+This BSIP separates the governance of the technical security of the blockchain from the governance of BitAssets.  BitAssets are a collection of special case SmartCoin which conflate blockchain governance and market effectiveness. To best serve the BitShares protocol, the existing set of BitAssets must be reconfigured to separate the concerns of block production, price feeds, and market operations; that is to say: deterministic consensus, non-deterministic external data, and smart contract settings.
+
+Therefore, this BSIP defines a process for BitAssets management to ensure protocol security remains the singular focus of the block producer role, and give BitAssets the best chance for long-term viability by nominating a new custodian to quickly react to market conditions.
+
+# Motivation
+Block production is an essential component of the BitShares platform itself, and as such should be expected to take an agnostic and neutral view towards the products deployed within the platform. Therefore, this BSIP will define a process for BitAsset management to ensure protocol security remains the singular focus of the block producer role and give BitAssets the best chance for long-term stability by nominating a new custodian to quickly react to market conditions. In order for the distributed consensus mechanism of DPOS to achieve adequate decentralization, it is imperative that block producers maintain strict independence from the politics of individual products deployed on the platform. 
+
+In short, this BSIP will put the BitAssets under the control of a new user account controlled by the stakeholders through a new type of voting. With this change, the newly appointed BitAssets manager will be able to independently maintain the parameters of their derivative asset without interference from the platform’s block producers and committee members. At the same time, the platform itself and its committee will not be unduly influenced by the demands of product management. An advantage gained by this is that the BitAsset manager will be able to react appropriately to rapidly changing market conditions, as may be required to properly maintain a successful derivative asset.
+
+# Rationale
+Because the BitAssets are currently controlled by platform-wide governance mechanisms, and because these are not well suited to the management of smart coins, which may at times need to respond quickly to market conditions, the authors propose to reorganize these assets to utilize a dedicated stakeholder-voted multisignature authority and thereby enable these assets to update in synchronization with market ebbs and flows.
+
+The block producers will no longer provide feeds for BitAssets. Instead another set of accounts will be authorized to provide feeds for BitAssets.  These accounts will be elected through stake-weighted voting with a new voting token called BITASSET.MANAGEMENT.  The initial distribution of this new voting token will be made equal to the current BTS distribution.  Subsequently, tokens of this new asset can be freely transferred or traded.
+
+Stake-weighted voting will also be used to elect a BitAsset Manager account (bitasset-manager) who will have the authority to change the settings of any BitAsset that are currently changeable by the Committee through proposals. The Committee will retain full control over the manager account, but is expected to leave day-to-day operations to the new elected entity.
+
+# Specification
+The following technical changes are required:
+
+**Assignment of Accumulated Fees**
+
+At the hardfork date, the accumulated fees of the existing BitAssets will be transferred to the committee-account.
+
+**Creation of BITASSET.MANAGEMENT asset**
+
+At the hardfork date, a new BITASSET.MANAGEMENT asset will be created with the committee account as its owner and all flags and permissions disabled. The initial distribution will be made equal to the current BTS distribution. BTS that are locked up in open orders, in collateral positions, in HTLC objects or in vesting balances will be assigned to the owners of the respective positions. Other BTS positions are out of scope (e. g. stealth).
+Subsequently, tokens of this new asset can be freely transferred or traded.
+
+**Add a feeding_authority extension to BitAssets**
+
+An extension will be added to `asset_update_bitasset_operation` that allows specifying an elected authority ([see BSIP-0084](bsip-0084.md)) for determining the list of feed producers. `asset_publish_feed_operation` will be adapted to check that authority if the extension is present on a BitAsset.
+
+**Addition of voting process through BITASSET.MANAGEMENT**
+
+Two new elected authorities ([see BSIP-0084](bsip-0084.md)) will be created based on the BITASSET.MANAGEMENT asset with settings that match the current voting mechanism (regarding min/max_number and proxy_allowed). The first one is for controlling the new bitasset-manager account (see below), the second one for selecting price feeders.
+
+**Update to Committee-Controlled BitAsset Issuer Fields**
+
+At the hardfork date, a new bitasset-manager account will be created with its owner and active authorities controlled by the committee.
+The committee-controlled BitAsset objects' issuer fields will be updated to specify this new account.
+After the hardfork, the new account will be able to assign other feed producers at its discretion.
+
+**Disable the witness_fed_asset and committee_fed_asset Flags**
+
+At the hardfork date, the `witness_fed_asset` and `committee_fed_asset` flags will be unset from all BitAssets, and will be disabled from use in future assets. Afterwards, the witnesses will still be able to provide a pricefeed, but the list of price feeders is no longer tied to the witness role. Instead, the list will have to be managed manually by the asset issuer, until the new feeding_authority is defined. This ensures a smooth transition without interrupting operations.
+
+**Activate elected authorities**
+
+By approving this BSIP, the shareholders instruct the committee to set the active authority of the bitasset manager account to the entity elected to act as the bitasset-manager account, and to set the feeding_authority extension of all BitAssets controlled by the bitasset-manager account to the entity elected for the curation of the price feed list, after sufficient shareholders have voted on the new entities, but no later than two weeks after the hardfork date.
+
+# Discussion
+
+## Worker Proposals
+
+Worker proposals were originally denominated in BitAssets with the intent to add liquidity in their respective markets, and advance them as a favored platform product. With BitAssets now being placed under the control of an independent manager, liquidity of a single particular product line is no longer the concern of the platform. A further implication of placing BitAssets under custodian control is that workers being paid in BitAssets would be exposed to the risk of devaluation and/or de-pegging at the custodian's discretion. Since this BSIP separates the BitAsset products from the platform, it may also sunset the tradition of preferentially denominating worker proposals in BitAssets, and free worker proposal authors to choose from a wider range of payout options, whether BitAsset or otherwise.
+
+## Comparison with Recent Committee Proposal
+
+The BitShares Committee has recently [assumed the selection of price feeders for some BitAssets](https://bitsharestalk.org/index.php?topic=29702.0).  This change shifts the selection of feed price providers from direct voting by BTS holders for block producers, who also provide feed prices, to indirect voting by BTS holders for Committee members. This is an applaudable first step.
+
+This BSIP goes further in that it decouples not only the selection for block producers from feed price providers, it also decouples the BitAsset ownership and management from the current committee. BTS holders will still be able to vote directly for Committee members and block producers. In addition, current BTS holders will be able to vote directly for feed price providers using their new BITASSET.MANAGEMENT tokens.
+
+# Summary
+
+In this BSIP the authors provide a unified solution to advance the project forward most efficiently. This proposal will decouple BitAssets from the rest of the BitShares platform with regard to governance. Instead, BitAssets can be controlled independently by a new BitAsset manager elected by interested parties. The platform will be governed by the elected witnesses and committee, as before. This BSIP does not impact non-BitAsset Smart Coins.
+
+# Copyright
+This document is placed into the public domain.


### PR DESCRIPTION
Against all processes in our community, BSIP-83 has been [removed at the decision of a single community member](248), despite the fact that [all his previous comments had been addressed and no further feedback has been provided for several days](238).
This PR re-adds the BSIP.