### PR TITLE
BSIP 80: Variant A

### DIFF
--- a/bsip-0080.md
+++ b/bsip-0080.md
@@ -1,0 +1,210 @@
+    BSIP: 80
+    Title: Short-Term Membership
+    Authors: <list of authors' real names and optionally, email addrs>
+    Status: Draft
+    Type: Protocol
+    Created: 2019-10-02
+    Discussion: https://github.com/bitshares/bsips/issues/232
+
+# Abstract
+
+A short-term membership is introduced to provide new marketers with a referral system that _may_ be sponsored by registrars.
+
+
+# Motivation
+
+Currently only life-time members can be referrers.  This can be perceived as a problem by potential referrers because it requires them to provide a relatively large investment before they can begin referring new accounts to the platform.  This drives away some potential marketers such as small bloggers.
+
+
+# Rational
+
+This BSIP proposes a protocol change to create a short-term membership (STM) with the ability to refer new accounts and earn referral fees.  This membership level shall have a finite duration and a membership fee that is _less than_ the fee for life-time membership (LTM).  A fee is necessary to pay for the RAM consumed by the account's vesting balance during its membership.
+
+New accounts that are referred by the STM account will have their operation fees distributed between the referring STM account, the new account's registrar, and an optional third LTM account.  This structure might motivate registrars or other LTM accounts to sponsor short-term memberships to the platform through an "STM upgrade faucet".
+
+
+## Definition of Short-Term Membership
+
+Short-term memberships shall allow an account to be used as a reference when new accounts are registered through a registrar.  As the referrer, the STM account shall receive [a portion of the operation fees](#fee-distribution) that are paid by the referred accounts.
+
+The STM fee and duration of the short-term membership shall be set by the Committee.  Any subsequent changes to the duration of short-term membership shall not affect STM accounts that exist at the time of a change by the Committee.
+
+
+## Upgrade Process
+
+The upgrade to STM status from a basic account shall set the account's referrer to the account itself.  The registrar and the lifetime referrer _shall not_ be changed by this upgrade.
+
+
+## <div id="fee-distribution"/> Distribution of Fees
+
+fee<sub>STM</sub> is the portion of an operation fee that is paid by every basic account referred by the STM account ("referred account") shall be calculated as:
+
+fee<sub>STM</sub> = fee &times; (1 - f<sub>network</sub> - f<sub>LTR</sub>) &times; f<sub>referrer</sub>
+
+where
+
+- _fee_ is the fee paid by the the referred account for any particular blockchain operation
+- f<sub>network</sub> is the fraction of the fee that is paid to the network.  This parameter is set by the BitShares Committee.
+- f<sub>LTR</sub> is the fraction of the fee that is paid to the account's lifetime referrer.  This parameter is set by the BitShares Committee.  An account's [lifetime referrer is initially defined when the account is created](https://github.com/bitshares/bitshares-core/blob/a7f4f071324c81a6033965e79141fffeb143c03f/libraries/chain/account_evaluator.cpp#L188); that lifetime referrer can be changed _to the referred account itself_ [if the referred account is upgraded to LTM status](https://github.com/bitshares/bitshares-core/blob/a7f4f071324c81a6033965e79141fffeb143c03f/libraries/chain/account_evaluator.cpp#L428).
+- f<sub>referrer</sub> is the fraction _of the remainder_, (1 - f<sub>network</sub> - f<sub>LTR</sub>), that is shared with the referring STM account.  0 &le; f<sub>referrer</sub> &le; 1.  The remainder of the remainder shall be distributed to the fee-paying account's registrar (R).
+
+For completeness, the network, the lifetime referrer (LTR), and the registrar (R) shall respectively receive:
+
+fee<sub>network</sub> = fee &times; f<sub>network</sub>
+
+fee<sub>LTR</sub> = fee &times; f<sub>LTR</sub>
+
+fee<sub>R</sub> = fee &times; (1 - f<sub>network</sub> - f<sub>LTR</sub>) &times; (1 - f<sub>referrer</sub>)
+
+
+### <div id="example-fees-paid-by-referred-basic"/> Example: Fees paid to an STM Account by a Referred Basic Account
+
+The network fee percentage (f<sub>network</sub>) is set by the Committee to 20%.  The lifetime referrer percentage (f<sub>LTM</sub>) is set by the Committee to 30%.
+
+An account (A) is registered by a registrar (R) which also records itself as the lifetime referrer., and referred by a LTM account (LTR).  Account A is upgraded _by the registrar_ to STM status.  Account A refers a basic account (B) to be registered by the same registrar (R) with referrer percentage (f<sub>referrer</sub>) set to 100%.  B's lifetime referrer will be set to A's lifetime referrer which is R.
+
+B pays an operation fee.  The distribution of the fee will be
+
+|Recipient|Percentage of fee|
+|-|-|
+|Network|20%|
+|Lifetime Referrer of B (R)|30%|
+|Referrer of B (A)|(100% - 20% - 30%) &times; 100% = 50%|
+|Registrar of B (R)|(100% - 20% - 30%) &times; (100% - 100%) = 0%|
+
+B's registrar (R) will receive a total of 30% of the fee, and Account A will receive 50% of the fee.
+
+#### <div id="example-fees-paid-by-referred-basic-after-stm-expiry"/> After STM expiration of A
+
+If A's STM expires, B's referrer will switch to B's lifetime referrer which is A's lifetime referrer (R).  The distribution of the fee will be
+
+|Recipient|Percentage of fee|
+|-|-|
+|Network|20%|
+|Lifetime Referrer of B (R)|30%|
+|Referrer of B (R)|(100% - 20% - 30%) &times; 100% = 50%|
+|Registrar of B (R)|(100% - 20% - 30%) &times; (100% - 100%) = 0%|
+
+B's registrar (R) will receive a total of 80% of the fee, and Account A will receive 0% of the fee.
+
+### <div id="example-fees-paid-by-referred-stm"/> Example: Fees paid to an STM Account by a Referred STM Account
+
+The network fee percentage (f<sub>network</sub>) is set by the Committee to 20%.  The lifetime referrer percentage (f<sub>LTM</sub>) is set by the Committee to 30%.
+
+An account (A) is registered by a registrar (R) which also records itself as the lifetime referrer.  Account A is upgraded _by the registrar_ to STM status.  Account A refers a basic account (B) to be registered by the same registrar (R) with referrer percentage (f<sub>referrer</sub>) set to 100%.  B's lifetime referrer will be set to A's lifetime referrer which is R.  The registrar (R) chooses to upgrade B to STM status.  _As a consequence of the upgrade to STM, B becomes its own referrer, Account A will receive 50% of the upgrade fee, and R will receive 30% of the upgrade fee (which is equivalent to a 30% refund of the upgrade fee)._
+
+B pays an operation fee.  The distribution of the fee will be
+
+|Recipient|Percentage of fee|
+|-|-|
+|Network|20%|
+|Lifetime Referrer of B (R)|30%|
+|Referrer of B (B)|(100% - 20% - 30%) &times; 100% = 50%|
+|Registrar of B (R)|(100% - 20% - 30%) &times; (100% - 100%) = 0%|
+
+B's registrar (R) will receive a total of 30% of the fee, _Account A will receive 0% of the fee_, and Account B will receive 50% of the fee.
+
+#### <div  id="example-fees-paid-by-referred-stm-after-stm-expiry"/> After STM expiry of A
+
+After the STM for Account A expires, Account A will continue not receiving any portion of the fees paid by Account B.
+
+#### <div  id="example-fees-paid-by-referred-stm-after-stm-expiry-of-b"/> After STM expiry of B
+
+If B's STM expires, B's referrer will switch to B's lifetime referrer which is A's lifetime referrer which is R.  The distribution of the fee will be
+
+|Recipient|Percentage of fee|
+|-|-|
+|Network|20%|
+|Lifetime Referrer of B (R)|30%|
+|Referrer of B (R)|(100% - 20% - 30%) &times; 100% = 50%|
+|Registrar of B (R)|(100% - 20% - 30%) &times; (100% - 100%) = 0%|
+
+B's registrar (R) will receive a total of 80% of the fee, _A will receive 0% of the fee_.
+
+
+### <div id="example-fees-paid-by-referred-ltm"/> Example: Fees paid to an STM Account by a Referred LTM Account
+
+The network fee percentage (f<sub>network</sub>) is set by the Committee to 20%.  The lifetime referrer percentage (f<sub>LTM</sub>) is set by the Committee to 30%.
+
+An account (A) is registered by a registrar (R), and referred by LTM account (LTR).  Account A is upgraded _by the registrar_ to STM status.  Account A refers another basic account (B) to be registered by the same registrar (R) with referrer percentage (f<sub>referrer</sub>) set to 100%.  B's lifetime referrer will be set to A's lifetime referrer which is R.  While B is a basic account, the fees are distributed as described in [the example for fees paid by a referred basic account](#example-fees-paid-by-referred-basic).
+
+_During the STM period, B chooses to upgrade itself to LTM_.  30% of the LTM upgrade fee is paid to B's lifetime referrer (R), and 50% to A.  _As a consequence of the upgrade to STM, B becomes its own referrer, lifetime referrer, and registrar._
+
+B pays an operation fee.  The distribution of the fee will be
+
+|Recipient|Percentage of fee|
+|-|-|
+|Network|20%|
+|Lifetime Referrer of B (B)|30%|
+|Referrer of B (B)|(100% - 20% - 30%) &times; 100% = 50%|
+|Registrar of B (B)|(100% - 20% - 30%) &times; (100% - 100%) = 0%|
+
+B will receive a total of 80% of the fee, _Account A will receive 0% of the fee_, and the registrar will receive 0% of the fee.
+
+#### <div id="example-fees-paid-by-referred-ltm-after-stm-expiry"/> After STM expiration
+
+After the STM for Account A expires, Account A will continue _not_ receiving any fees paid by Account B.
+
+### <div id="example-comparison"/> Comparison of Fee Distributions Across the Examples
+
+The table below summarizes the distribution of fees paid by an account referred by an STM account across the different examples.  The two major variables are whether the STM account (Account A) is active or has expired, and which membership level is held by the referred account (Account B).
+
+|Example|Network|R|A|B|
+|-|-|-|-|-|
+|[Fees Paid by Referred Basic Account](#example-fees-paid-by-referred-basic)|20%|30%|50%|0%|
+|[Fees Paid by Referred Basic Account after STM expiry of Account A](#example-fees-paid-by-referred-basic-after-stm-expiry)|20%|0%|0%|80%|0%|
+|[Fees Paid by Referred STM Account](#example-fees-paid-by-referred-stm)|20%|30%|50%|0%|
+|[Fees Paid by Referred STM Account after STM expiry of Account A](#example-fees-paid-by-referred-stm-after-stm-expiry)|20%|30%|50%|0%|
+|[Fees Paid by Referred STM Account after STM expiry of Account B](#example-fees-paid-by-referred-stm-after-stm-expiry-of-b)|20%|80%|0%|0%|
+|[Fees Paid by Referred LTM Account](#example-fees-paid-by-referred-ltm)|20%|0%|0%|80%|
+|[Fees Paid by Referred LTM Account after STM expiry of Account A](#example-fees-paid-by-referred-ltm-after-stm-expiry)|20%|0%|0%|80%|
+
+## Retained Fees
+
+The referral fees that are retained for the STM account shall be retained within a vesting balance for that account.  The vesting balances shall be claimable in the same manner that other vesting balances can be claimed.
+
+## Extension of STM
+
+An active STM may be extended while it is active.  The expiration date will be extended by the STM duration that is set by the Committee _at the time of the extension_.
+
+## Upgrade of STM status to LTM status
+
+If the account is upgraded to a lifetime membership before the expiry of the short-term membership, the vesting balance shall be retained with the account; the short-term membership shall cease to be in effect when the upgrade occurs.
+
+The account shall becomes its own referrer, lifetime referrer, and registrar.
+
+## Expiry of STM
+
+If an account's STM status expires, the account's status will revert to basic account.  The account's referrer shall be set to the account's lifetime referrer account.
+
+
+# Specifications
+
+TBD
+
+
+# Discussion
+
+## Maximum Fee Distribution to STM Accounts
+
+The Committee can effectively increase the fee percentage that _can potentially_ be received by the STM account by reducing either of two blockchain parameters, the LTM referrer fee percentage or the network fee percentage towards 0%.
+
+The registrar of **new accounts** can effectively increase the fee percentage that _can potentially_ be received by a STM account by registering those _specific accounts_ with a derived registrar percentage of 0%; the explicit manner of accomplishing this for an STM account is by registering the account with a referrer percentage towards 100%.
+
+Because this percentage would effectively deprive the registrar of its portion of future fees _and_ because _any random account might not elect to upgrade itself to STM status_, the practical manner of increasing an STM account's fee percentage is for a registrar to offer an "STM faucet" that executes two actions when registering a new account:
+
+1. Register a new account with a referrer percentage equal to 100%
+2. Upgrade the new account to STM status
+
+
+# Summary for Shareholders
+
+This proposal offers a mechanism where new marketers can begin referring without becoming a lifetime member (LTM).  The mechanism involves a new short term membership (STM) which costs less than LTM, and which is structured to incentivize registrars to pay for the STM membership so that new marketers need not pay anthing to begin marketing BitShares.
+
+# Copyright
+
+This document is placed in the public domain.
+
+# See Also
+
+TBD


### PR DESCRIPTION
This is a baseline variant of a possible short-term membership for #232.  It is largely modeled after the old annual membership and is intended to aid discussion for other variants.