### PR TITLE
1000:1 Reverse Split of Core BTS Token

### DIFF
--- a/bsip-0086.md
+++ b/bsip-0086.md
@@ -1,0 +1,82 @@
+    BSIP: BSIP 86
+    Title: 1000:1 Reverse Split of Core BTS Token
+    Authors: litepresence finitestate@tutamail.com
+    Status: Draft
+    Type: Protocol
+    Created: 2019-12-30 
+    Discussion: bitsharestalk.org/
+
+
+# Abstract
+
+As we approach Jan 1, 2020, the current trading price for BTS core token has fallen below 200 satoshi.  It also fell below 200 satoshi in February 2018.  Since inception, the price of the core BTS token has spent about 50% of its time below 1000 satoshi.  Having spent half of its time below 1000 satoshi, BTS has spent half of its lifetime with only 3 significant figures to trade at centralized exchanges. 
+
+In stock markets, stock splits and reverse stock splits are routine actions performed by corporations upon consent of shareholders.  We find in traditional stock markets prices are maintained such that there are always between 4 and 5 significant figures vs. the national currency.   That is, most stock prices, in high volume markets, typically range from 10.00 to 999.99.   When they get outside of that range, stock split; or reverse stock split is a routine consideration taken up among shareholders and initiated by corporate management.   
+
+Exchanges do not tend to change their UI or back-end to accommodate assets which do not fit within their existing framework.  In Bitcoin markets that framework allows for precision up to 8 digits; 0.00000000.   
+
+
+# Motivation
+
+The motivation of this split is to increase share price immediately to prevent delisting risk, encourage listing acceptance at new exchanges, and more generally encourage higher trade volume at centralized exchanges by removing the delisting threat.    
+
+
+# Rational
+
+Exchanges generally specify a minimum bid price for an asset to be listed. If the stock falls below this bid price and remains lower than that threshold level over a certain period, it risks being delisted from the exchange.  In the cryptocurrency space this price threshold is proprietary, though experience shows it is typically set between 200 and 500 satoshi.  Secondly, in fear of delisting, traders are hesitant to purchase an asset who's exchange price is approaching the threshold for delisting.   Over time this rational fear decreases trading volume which has a cascading effect on the already weakened asset.  Typically when a coin is delisted from exchange there is an immediately negative effect on market price.   
+
+Additionally, when an asset price is at the bottom end of 3 significant figures, such as, in the current case of Bitshares at 200 satoshi; there is now 0.5% change in value for every up or down tick in price.  At 100 satoshi, that becomes one full percent change in value for every tick in tradable asset price vs BTC (the core currency BTS is traded against at most exchanges).  The core properties of money are Durability, Portability, Divisibility and Intrinsic value.   When price is moving in ticks of half a percent at every trade, the properties of Divisibility and Intrinsic Value come into question.  
+
+In traditional stock markets, upon a reverse stock split there is an immediate and proportional change in market price to the split.   Instead of trading at 0.00000200 in CEX markets, Bitshares would immediately trade at 0.00200000.   Markets are very reliable and resilient in this regard.   The delisting risk profile would immediately and permanently change.  
+
+The BTSUSD price, likewise would move from $0.0149 (current) to $14.90 on open markets.  This would open doors for BTSUSD markets, where exchanges specify price in cents, to be a rational consideration. 
+
+
+# Specifications
+
+The specification for this change is simple:
+
+1000:1 reverse split
+Core token asset precision changed from 5 to 8
+All open orders on DEX vs the core BTS token would be scaled accordingly
+All loans used to issue bitASSETs would also be scaled
+
+Put simply:
+
+However many BTS are in existence is divided by 1000.  However many you have personally is divided by 1000.  
+
+If there is rounding to be done, round down.
+
+
+# Discussion
+
+bitsharestalk.org/
+
+
+# Summary for Shareholders
+
+
+Significant figures in financial markets send key signals to both traders and exchange operators.   BTS has consistently traded at 3 significant figures.   Making this change to the core protocol will eliminate delisting risk at centralized exchanges due to the very concrete issue of divisibility vs the value of Bitcoin. 
+
+
+# Copyright: 
+
+WTFPL - wtfpl.net
+
+
+# See Also
+
+"The number one reason for a reverse stock split is because the stock exchanges—like the NYSE or Nasdaq—set minimum price requirements for shares that trade on their exchanges. And when a company’s shares decline to near—or below—that level, the easiest way to stay in compliance with the exchange is to reduce the number of outstanding shares so that the price of the individual shares—like magic—automatically rises. And when that happens, the company’s shares can remain trading on the exchange."
+
+https://cabotwealth.com/daily/how-to-invest/reverse-stock-splits-shareholders/
+
+# Additional Resources
+
+https://www.investopedia.com/terms/r/reversesplit.asp
+https://www.investopedia.com/ask/answers/06/reversestocksplit.asp
+https://www.fool.com/knowledge-center/whats-a-reverse-stock-split-and-can-it-really-help.aspx
+https://www.wallstreetmojo.com/reverse-stock-split
+https://en.wikipedia.org/wiki/Reverse_stock_split
+https://www.upcounsel.com/reverse-stock-split
+https://www.stocksplithistory.com/reverse-stock-splits
+https://finance.zacks.com/reverse-stock-split-good-bad-2298.html


### PR DESCRIPTION
The motivation of this split is to increase share price immediately to prevent delisting risk, encourage listing acceptance at new exchanges, and more generally encourage higher trade volume at centralized exchanges by removing the delisting threat.    