### PR TITLE
Update bsip-0086.md clarity, destination of funds to committee

### DIFF
--- a/bsip-0086.md
+++ b/bsip-0086.md
@@ -10,26 +10,27 @@
 # Abstract
 
 This BSIP proposes a protocol change: Every time a trade is executed (limit order is filled) and
-if there are market fees generated, a portion of the market fees goes to the network.
+if there are market fees generated, a portion of the market fees goes to the `committee-account`.
 
-Example: The network percent of market fees is set to 50%, and 0.2% of trading volume is the set as market fee. 
-Then 0.1% of trading volume goes to the Committee.
+Example: The committee percent of market fees is set to 50%, and 0.2% of trading volume is the set as market fee. 
+Then 0.1% of trading volume goes to the `committee-account`.
 
 # Motivation
 
-The network needs more tools to generate income to support its development.
+The BitShares Committee needs more tools to generate income to support development.
 
 # Rationale
 
-A major activity in the network is trading assets. The asset owners make
-profits in the form of market trading fees. Currently, the main tools for the
-network to generate income from asset trading activities are order creation
-fee and order cancellation fee. It seems reasonable that the asset owners
-share some profits (a part of market fees) to the network to support its
-development.
+A major activity in the **network** is trading assets. The asset owners make
+profits in the form of market trading fees. 
 
-The cut of market fees can go to committee-account's vesting balances.
-As a supporting measure, committee-account should be exempted from
+Currently, the main tools for the **network** to generate income from asset 
+trading activities are order flat fill order fee and flat order cancellation fee. 
+
+It seems reasonable that the asset owners share some variable profits 
+(a part of market fees) to the `committee-account`, to support development.
+
+As a supporting measure, `committee-account` should be exempted from
 white-listing restrictions, so that it is able to claim the vesting balances
 and sell them for core token or other tokens to pay for development later.
 
@@ -51,15 +52,17 @@ Valid range of that parameter is `[0%, 100%]`.
 
 ## When processing market fees
 
+The cut of market fees can go to `committee-account`'s vesting balances.
+
 After the protocol upgrade, when splitting a non-zero market fee, firstly
-split `amount * market_fee_committee_percent` (round down) to committee-account,
-then process the remainder as before. The amount split to committee-account
+split `amount * market_fee_committee_percent` (round down) to `committee-account`,
+then process the remainder as before. The amount split to `committee-account`
 should go to the vesting balance object whose type is `market_fee_sharing`.
 
 ## When checking asset authorities
 
 After the protocol upgrade, when checking authorities (E.G. white-lists) of an
-asset on an account, if the account is committee-account, let it pass.
+asset on an account, if the account is `committee-account`, let it pass.
 
 # Discussion
 
@@ -95,22 +98,22 @@ asset on an account, if the account is committee-account, let it pass.
  a fee from asset owners, which kills some freedom and would hinder non-profit
  use of the platform.
 
-* It is possible that committee-account would accumulate a lot of tokens with no
+* It is possible that `committee-account` would accumulate a lot of tokens with no
  value and tokens which are unable or hard to be used to pay for development.
  It is a side effect. Hopefully there will be quite some usable tokens.
- The committee will have to do some work to manage the tokens anyway.
+ The Committee will have to do some work to manage the tokens anyway.
 
-* The committee will be accumulating tokens which could potentially be used or
+* The Committee will be accumulating tokens which could potentially be used or
  not used for any purpose. In other words, this BSIP as currently written does
- not stipulate how those tokens will or will not be used by the committee.
+ not stipulate how those tokens will or will not be used by the Committee.
 
 # Non-Technical Summary
 
-This BSIP adds a tool for the committee to impose a fee on market trading
+This BSIP adds a tool for the Committee to impose a fee on market trading
 fees for all assets which enabled market trading fee, thus it can increase income 
-for the committee to support development. It may 
-hinder businesses relying on market fees if the committee-decided fee is high.
-The committee may need some efforts to decide on an appropriate value of the parameter and manage the income.
+for the committee to support development. It may hinder businesses relying on Market 
+Fees if the committee decided fee is high. The committee may need some efforts to 
+decide on an appropriate value of the parameter and manage their income.
 
 # Copyright
 

--- a/bsip-0086.md
+++ b/bsip-0086.md
@@ -1,5 +1,5 @@
     BSIP: 0086
-    Title: Share Market Fees to with the BitShares Committee
+    Title: Share Market Fees with the BitShares Committee
     Author: Abit More <https://github.com/abitmore>
     Status: Approved
     Type: Protocol
@@ -12,8 +12,8 @@
 This BSIP proposes a protocol change: Every time a trade is executed (limit order is filled) and
 if there are market fees generated, a portion of the market fees goes to the `committee-account`.
 
-Example: The committee percent of market fees is set to 50%, and 0.2% of trading volume is the set as market fee. 
-Then 0.1% of trading volume goes to the `committee-account`.
+Example: The committee percent of market fees is set to 30%, and 0.2% of trading volume is the set as market fee. 
+Then 0.06% of trading volume goes to the `committee-account`.
 
 # Motivation
 
@@ -49,6 +49,8 @@ Add a new global parameter `market_fee_committee_percent` which can be updated
 by the committee only after the protocol upgrade.
 Initial value of that parameter is `0%`.
 Valid range of that parameter is `[0%, 100%]`.
+
+UPDATE: for [0,100%] to [0,30%] https://github.com/bitshares/bsips/pull/269
 
 ## When processing market fees
 

--- a/bsip-0086.md
+++ b/bsip-0086.md
@@ -50,7 +50,7 @@ by the committee only after the protocol upgrade.
 Initial value of that parameter is `0%`.
 Valid range of that parameter is `[0%, 100%]`.
 
-UPDATE: for [0,100%] to [0,30%] https://github.com/bitshares/bsips/pull/269
+UPDATE: limit `[0,100%]` to `[0,30%]` see: https://github.com/bitshares/bsips/pull/269
 
 ## When processing market fees
 

--- a/bsip-0086.md
+++ b/bsip-0086.md
@@ -1,5 +1,5 @@
     BSIP: 0086
-    Title: Share market fees to the network
+    Title: Share Market Fees to with the BitShares Committee
     Author: Abit More <https://github.com/abitmore>
     Status: Approved
     Type: Protocol
@@ -13,7 +13,7 @@ This BSIP proposes a protocol change: Every time a trade is executed (limit orde
 if there are market fees generated, a portion of the market fees goes to the network.
 
 Example: The network percent of market fees is set to 50%, and 0.2% of trading volume is the set as market fee. 
-Then 0.1% of trading volume goes to the network.
+Then 0.1% of trading volume goes to the Committee.
 
 # Motivation
 
@@ -44,7 +44,7 @@ the scheduled time, at the scheduled time and after the scheduled time.
 
 ## New global parameter
 
-Add a new global parameter `market_fee_network_percent` which can be updated
+Add a new global parameter `market_fee_committee_percent` which can be updated
 by the committee only after the protocol upgrade.
 Initial value of that parameter is `0%`.
 Valid range of that parameter is `[0%, 100%]`.
@@ -52,7 +52,7 @@ Valid range of that parameter is `[0%, 100%]`.
 ## When processing market fees
 
 After the protocol upgrade, when splitting a non-zero market fee, firstly
-split `amount * market_fee_network_percent` (round down) to committee-account,
+split `amount * market_fee_committee_percent` (round down) to committee-account,
 then process the remainder as before. The amount split to committee-account
 should go to the vesting balance object whose type is `market_fee_sharing`.
 
@@ -66,20 +66,20 @@ asset on an account, if the account is committee-account, let it pass.
 * Other than [the "coin-days as market fees" proposal](
  https://github.com/bitshares/bsips/issues/191) which applies
  a discount to market fees to benefit core token holders directly, this BSIP
- seeks for a mechanism to increase the network's income and benefit core token
+ seeks for a mechanism to increase the committee's income and benefit core token
  holders indirectly.
 
-* Adjusting the fee schedule and network percent in the referral program is
- another option to increase the network's income, and is probably sufficient
+* Adjusting the fee schedule and committee percent in the referral program is
+ another option to increase the committee's income, and is probably sufficient
  for funding development.
 
 * In the original design, the purpose of market fees is to reward asset
  issuers for their work (e.g. gateway providers, or businesses built around
  PMs), while operation fees (`limit_order_create/cancel` in particular) reward
- the network for performing its work. The separation of market/operation fees
+ the committee for performing its work. The separation of market/operation fees
  matches the separation of roles. Changing this may damage existing businesses.
  Thus this BSIP could be a bad idea from this perspective. Also note that the
- network can profit from market fees by setting them on committee-owned tokens.
+ committee can profit from market fees by setting them on committee-owned tokens.
 
 * This would be another motivation for businesses building on top of BitShares
  to get involved in the parameter governance process. The percentage can be
@@ -90,7 +90,7 @@ asset on an account, if the account is committee-account, let it pass.
  It is uncommon nowadays probably because it is less convenient or attractive
  for their customers.
 
-* Another strategy is to charge a network market fee globally, independent of
+* Another strategy is to charge a committe market fee globally, independent of
  what the asset owner decides. It essentially removes the option to not set
  a fee from asset owners, which kills some freedom and would hinder non-profit
  use of the platform.
@@ -108,7 +108,7 @@ asset on an account, if the account is committee-account, let it pass.
 
 This BSIP adds a tool for the committee to impose a fee on market trading
 fees for all assets which enabled market trading fee, thus it can increase income 
-for the network to support its development. It may 
+for the committee to support development. It may 
 hinder businesses relying on market fees if the committee-decided fee is high.
 The committee may need some efforts to decide on an appropriate value of the parameter and manage the income.
 


### PR DESCRIPTION
BSIP0086 proposing funding the committee vesting account; not network through the reserve pool.   

QUOTE:
`The cut of market fees can go to committee-account's vesting balances.`

Throughout the document however there are several mentions of the network, which implies reserve pool.  Updated document to clarify by ensuring all mention of network was changed to committee. 

EXAMPLE:
`this BSIP seeks for a mechanism to increase the network's income `

SHOULD BE:
`this BSIP seeks for a mechanism to increase the committee's income `


I also suggest updating the variable

`market_fee_network_percent`

to 

`market_fee_committee_percent`

There is substantive difference between funding the network through reserve pool and funding the committee through committee account vesting balances.   

There was only one mention of where the funds went and that was "committee account vesting balances".    All other mentions were of "network income".   

This PR and the final resting place of BSIP86 funds might be a miscommunication error and should be discussed with voters before this implementation detail is finalized.