### PR TITLE
BSIP 74 Specification Clarification

### DIFF
--- a/bsip-0074.md
+++ b/bsip-0074.md
@@ -11,26 +11,36 @@ Worker: TBD
 ```
 
 # Abstract
-This BSIP provide a solution to charge fee from margin call trading.
+This BSIP provides a solution to charge a fee for margin call trading.
 
 # Motivation
-Bitshares community becomes more and more aware that BTS need a powerful economy model, one simple selection is to charge the tradings and buy back BTS using the accumulated fees, as did in many exchange platform tokens, the continuous income can help to provide smartcoin liquidity and sustain BTS price. Margin call tradings are potential to contribute a big part of the income to the system, however up to now the margin call trading is not charged, we need to find a suitable way to get this part of system income.
+The BitShares community has become more and more aware that BTS need a powerful economic model. One simple selection is to charge for trading and use the accumulated fees to buy back BTS, as is done with many exchanges' platform tokens. The continuous income can help to provide smartcoin liquidity and sustain the price of BTS. Margin call trading has the potential to make a large contribution to the income of the system. However, up until now margin call trading is not charged for. We need to find a suitable way for this to add to the system's income.
 
 # Rationale
-Margin call fee can be seen as to pay the cost for smartcoin supply and stabilization, it is irrelevant to market fee sharing.
+A margin call fee can be seen as a way to pay part of the cost for smartcoin supply and stabilization. It is unrelated to market fee sharing.
 
-To ensure the debt positions can always be closed with suffcient smartcoin, it is more feasible to cut off part of the traded collaterals as fee, instead of smartcoin.
+To ensure the debt positions can always be closed with suffcient smartcoin, it is more feasible to charge part of the traded collaterals as the fee, instead of the smartcoin.
 
-As the margin call fee ratio may be obvious higher than market fee, the margin call orders should be placed at the real price without margin call fee to avoid misleading the buyer.
+As the margin call fee ratio may be obviously higher than market fee, the margin call orders should be placed at the actual price without margin call fee. This will avoid misleading the buyer.
 
 # Specification
 Add one new parameter Margin Call Fee Ratio(MCFR) for each smartcoin, which is controlled by the smartcoin owner.
 
-`Margin call order price = settlement price/(MSSR-MCFR)`.
+**Case 1:** In the case of the call order being the maker,
 
-Here settlement price is a new introduced parameter which is defined in BSIP71, settlement price = feed price when there is no bad debt.
+`Margin call match price = settlement price/(MSSR-MCFR)`.
 
-When a margin call trading happens, the buyer sells smartcoin with quantity X and get collaterals in quantity `X*(MSSR-MCFR)/settlement price`, the margin call order owner sells collaterals in quantity `X*MSSR/settlement price` and get smartcoin in quantity X, the delta in paid and received collaterals in `quantity X*MCFR/settlement price` will be paid to the owner of the smartcoin as margin call fee.
+Here `settlement price` is a new parameter introduced as part of [BSIP71](bsip-0071.md). Note that `settlement price = feed price` when there is no bad debt.
+
+When margin call trading happens with the call order as the maker, the buyer sells smartcoin with quantity X and get collaterals in quantity `X*(MSSR-MCFR)/settlement price`, the margin call order owner sells collaterals in quantity `X*MSSR/settlement price` and get smartcoin in quantity X, the delta in paid and received collaterals (quantity `X*MCFR/settlement price`) will be paid to the owner of the smartcoin as the margin call fee.
+
+**Case 2:** In the case of the call order being the taker,
+
+`Margin call match price = settlement price/MSSR`.
+
+Note that MCFR does not come into play for order matching in this case, but it is involved in the calculation of collateral that is returned to the call order owner.
+
+When margin call trading happens with the call order as the taker, the buyer sells smartcoin with quantity X and receives collateral in quantity `X*MSSR/settlement price`, the margin call order owner sells collateral in quantity `X*(MSSR-MCFR)/settlement price` and get smartcoin in quantity X, the delta in paid and received collaterals (quantity `X*MCFR/settlement price`) will be paid to the owner of the smartcoin as the margin call fee.
 
 # Copyright
 This document is placed in the public domain.

--- a/bsip-0074.md
+++ b/bsip-0074.md
@@ -19,7 +19,7 @@ The BitShares community has become more and more aware that BTS need a powerful 
 # Rationale
 A margin call fee can be seen as a way to pay part of the cost for smartcoin supply and stabilization. It is unrelated to market fee sharing.
 
-To ensure the debt positions can always be closed with suffcient smartcoin, it is more feasible to charge part of the traded collaterals as the fee, instead of the smartcoin.
+To ensure the debt positions can always be closed with sufficient smartcoin, it is more feasible to charge part of the traded collaterals as the fee, instead of the smartcoin.
 
 As the margin call fee ratio may be obviously higher than market fee, the margin call orders should be placed at the actual price without margin call fee. This will avoid misleading the buyer.
 
@@ -40,7 +40,7 @@ When margin call trading happens with the call order as the maker, the buyer sel
 
 Note that MCFR does not come into play for order matching in this case, but it is involved in the calculation of collateral that is returned to the call order owner.
 
-When margin call trading happens with the call order as the taker, the buyer sells smartcoin with quantity X and receives collateral in quantity `X*MSSR/settlement price`, the margin call order owner sells collateral in quantity `X*(MSSR-MCFR)/settlement price` and get smartcoin in quantity X, the delta in paid and received collaterals (quantity `X*MCFR/settlement price`) will be paid to the owner of the smartcoin as the margin call fee.
+When margin call trading happens with the call order as the taker, the buyer sells smartcoin with quantity X and receives collateral in quantity `X/limit order price`, the margin call order owner sells collateral in quantity `X/limit order price*(1+MCFR)` and gets smartcoin in quantity X, the delta in paid and received collaterals (quantity `X*MCFR/limit order price`) will be paid to the owner of the smartcoin as the margin call fee.
 
 # Copyright
 This document is placed in the public domain.


### PR DESCRIPTION
**Note 1:** It is not the intent of this PR to change the mechanics, only to clarify the specifications of BSIP 74. Please review these changes carefully to assure the integrity of the original BSIP, and the accuracy of the specifications.

**Note 2:** Implementing BSIP74 reduces the "window" of matching limit orders by the MCFR in Case 1. It is assumed the reader understands that, and that issuers will be judicious with their selection of MCFR values. Is it appropriate (or desired) to add this note to this BSIP?

**Note 3:** These specifications do not dictate what should happen if the collateral is insufficient to pay the margin trading fee. Perhaps (a) the fee takes what it can, or (b) the match fails. If (b), what happens next? Perhaps there is a (c) that I have not thought of.