### PR TITLE
Update status of several BSIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Number             | Title                                                    | 
 [74](bsip-0074.md) | Margin Call Fee Ratio | Jerry Liu | Protocol | Draft
 [75](https://github.com/bitshares/bsips/issues/96) | Asset Owner Defines MCR and MSSR Values | John Jones | Protocol | Draft
 [76](bsip-0076.md) | Committee-Defined SmartAsset Collateral Threshold | Abit More | Informational | Draft
-[77](bsip-0077.md) | Require Higher CR When Creating / Adjusting Debt Positions | Abit More | Protocol | Accepted
+[77](bsip-0077.md) | Require Higher CR When Creating / Adjusting Debt Positions | Abit More | Protocol | Approved
 [81](bsip-0081.md) | Simple Maker-Taker Market Fees | Abit More | Protocol | Draft
 [84](bsip-0084.md) | Elections Based on non-Core Asset | Peter Conrad | Protocol | Draft
 [85](bsip-0085.md) | Maker Order Creation Fee Discount | Abit More | Protocol | Draft

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Number             | Title                                                    | 
 [71](bsip-0071.md) | Add "Prevent Global Settlement" Flag for Smartcoin  | Jerry Liu | Protocol | Draft
 [72](bsip-0072.md) | Tanks and Taps: A General Solution for Smart Contract Asset Handling | Nathan Hourt | Protocol | Draft
 [73](bsip-0073.md) | Match Force-Settlement Orders with Margin Calls and Limit Orders | Abit More | Protocol | Draft
-[74](bsip-0074.md) | Margin Call Fee Ratio | Jerry Liu | Protocol | Draft
-[75](https://github.com/bitshares/bsips/issues/96) | Asset Owner Defines MCR and MSSR Values | John Jones | Protocol | Draft
+[74](bsip-0074.md) | Margin Call Fee Ratio | Jerry Liu | Protocol | Approved
+[75](bsip-0075.md) | Asset Owner Defines MCR and MSSR Values | John Jones | Protocol | Accepted
 [76](bsip-0076.md) | Committee-Defined SmartAsset Collateral Threshold | Abit More | Informational | Draft
 [77](bsip-0077.md) | Require Higher CR When Creating / Adjusting Debt Positions | Abit More | Protocol | Approved
-[81](bsip-0081.md) | Simple Maker-Taker Market Fees | Abit More | Protocol | Draft
+[81](bsip-0081.md) | Simple Maker-Taker Market Fees | Abit More | Protocol | Approved
 [84](bsip-0084.md) | Elections Based on non-Core Asset | Peter Conrad | Protocol | Draft
-[85](bsip-0085.md) | Maker Order Creation Fee Discount | Abit More | Protocol | Draft
+[85](bsip-0085.md) | Maker Order Creation Fee Discount | Abit More | Protocol | Approved
 [86](bsip-0086.md) | Share market fees to the network | Abit More | Protocol | Approved
-[87](bsip-0087.md) | Force Settlement Fee | Jerry Liu | Protocol | Accepted
+[87](bsip-0087.md) | Force Settlement Fee | Jerry Liu | Protocol | Approved
 
 

--- a/bsip-0074.md
+++ b/bsip-0074.md
@@ -3,7 +3,7 @@ BSIP: 0074
 Title: Margin Call Fee Ratio
 Authors:
   Jerry Liu bitcrab@qq.com
-Status: Draft
+Status: Approved
 Type: Protocol
 Created: 2019-09-07
 Discussion: https://github.com/bitshares/bsips/issues/164

--- a/bsip-0077.md
+++ b/bsip-0077.md
@@ -2,7 +2,7 @@
     Title: Require Higher CR When Creating / Adjusting Debt Positions
     Authors: Abit More
              @shulthz
-    Status: Accept
+    Status: Approved
     Type: Protocol
     Created: 2019-09-30
 

--- a/bsip-0081.md
+++ b/bsip-0081.md
@@ -1,7 +1,7 @@
     BSIP: 0081
     Title: Simple Maker-Taker Market Fees
     Author: Abit More <https://github.com/abitmore>
-    Status: Draft
+    Status: Approved
     Type: Protocol
     Created: 2019-10-02
     Discussion: https://github.com/bitshares/bsips/issues/229

--- a/bsip-0085.md
+++ b/bsip-0085.md
@@ -1,7 +1,7 @@
     BSIP: 0085
     Title: Maker order creation fee discount
     Author: Abit More <https://github.com/abitmore>
-    Status: Accepted
+    Status: Approved
     Type: Protocol
     Created: 2019-10-13
     Discussion: https://github.com/bitshares/bsips/issues/240

--- a/bsip-0087.md
+++ b/bsip-0087.md
@@ -2,7 +2,7 @@
     Title: Force Settlement Fee
     Authors:
       Jerry Liu bitcrab@qq.com
-    Status: Accepted
+    Status: Approved
     Type: Protocol
     Created: 2020-02-23
     Discussion: https://github.com/bitshares/bsips/issues/260


### PR DESCRIPTION
They had been approved for months, although at this moment their votes are below `refund400k`.